### PR TITLE
Add doctype node type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ module.exports = function ReshapeParser (input, options = {}) {
     if (sid) { tag += ` "${sid}"` }
     tag += '>'
 
-    const node = { type: 'text', content: tag }
+    const node = { type: 'doctype', content: tag }
     addLocation(node, location, options)
 
     result.push(node)

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,7 @@ test('head/body', t => {
   const str =
     '<!doctype html><html><head><link rel="stylesheet" href="/style.css"></head><body><p>hi!</p></body></html>'
   const out = parser(str)
-  t.truthy(out[0].type === 'text')
+  t.truthy(out[0].type === 'doctype')
   t.truthy(out[0].content.match(/!DOCTYPE/))
   t.truthy(out[1].name === 'html')
   t.truthy(out[1].content[0].name === 'head')


### PR DESCRIPTION
Previously we were processing the doctype as a text node, but now that [html entity serialization has been improved](https://github.com/reshape/code-gen/commit/5bbb7ec1e29df85ff80c8788c858fa70ae85a037), it needs its own doctype not to be escaped.